### PR TITLE
Add HTTPS encryption between ESP32 and Flask server

### DIFF
--- a/Flask_Server/app.py
+++ b/Flask_Server/app.py
@@ -67,9 +67,9 @@ def run_flask(Ip, Port):
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind((Ip, Port))
-        print(f"[INFO] Flask Server running on: {Ip}:{Port}")
-        app.run(host=Ip, port=Port)
-        return True
+            print(f"[INFO] Flask Server running on: {Ip}:{Port}")
+            app.run(host=Ip, port=Port, ssl_context='adhoc')
+            return True
     except OSError as e:
         print(f"[ERROR] {Ip}:{Port} is not available to bind {e}")
         return False

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A complete IoT project using an ESP32 (NodeMCU-32S) development board to collect
 
 ## Architecture
 
-[ESP32] --(via HTTP POST)--> [Flask API Server (Python)] --> [SQLite / CSV] --> [Web UI]
+[ESP32] --(via HTTPS POST)--> [Flask API Server (Python)] --> [SQLite / CSV] --> [Web UI]
 
 ### ESP32 Flowchart
 Overall process as below flowchart, including two processes: 1) Initialization. 2) Loop
@@ -23,7 +23,8 @@ Loop process responsible for reading temperature and himidity data, then send th
 
 - ESP32-based data acquisition using DHT22 sensor
 - Fetch sensor calibration data when system startup
-- Send temperature and humidity data via HTTP POST to Flask server
+- Send temperature and humidity data via HTTPS POST to Flask server
+- Encrypted communication using a self-signed TLS certificate
 - SQLite for simple and lightweight storage
 - REST API endpoints for data access
 - Chart.js front-end for real-time graph display

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include <WiFi.h>
+#include <WiFiClientSecure.h>
 #include <HTTPClient.h>
 #include "DHT.h"
 #include <ArduinoJson.h>
@@ -20,8 +21,8 @@ Preferences Prefs;
 
 const char* ssid = "SWIFT14";
 const char* password = "77754321";
-const char* uploadServerUrl = "http://192.168.137.1:5000//upload";
-const char* calibrationServerUrl = "http://192.168.137.1:5000//api//calibration";
+const char* uploadServerUrl = "https://192.168.137.1:5000/upload";
+const char* calibrationServerUrl = "https://192.168.137.1:5000/api/calibration";
 
 
 static CalibrationData_T CalibrationData = {0};
@@ -56,8 +57,10 @@ static void saveHumidityCalibration(float humidityOffset)
 
 static void fetchCalibration(CalibrationData_T *RemotedCalibrationData)
 {
+  WiFiClientSecure client;
+  client.setInsecure();
   HTTPClient http;
-  http.begin(calibrationServerUrl);
+  http.begin(client, calibrationServerUrl);
   int httpCode = http.GET();
   if (httpCode == 200)
   {
@@ -162,8 +165,10 @@ void loop(void)
 #if SERIALPRINT_ENABLE
     Serial.printf("Temperature %.1f degree Celcius, Humidity: %.1f %%\n", temperature, humidity);
 #endif
-    HTTPClient http;
-    http.begin(uploadServerUrl);
+      WiFiClientSecure client;
+      client.setInsecure();
+      HTTPClient http;
+      http.begin(client, uploadServerUrl);
     temperature = temperature - CalibrationData.tempOffset;
     humidity = humidity - CalibrationData.humidityOffset;
 
@@ -171,8 +176,8 @@ void loop(void)
     String json = "{\"temperature\":" + String(temperature) + 
                   ",\"humidity\":" + String(humidity) + "}"; /* {temperature: value, humidity*: value} */
 
-    int httpResponse = http.POST(json);
-    http.end();
+      int httpResponse = http.POST(json);
+      http.end();
   }
   delay(2000);
 }


### PR DESCRIPTION
1. Use `WiFiClientSecure` and HTTPS endpoints on the ESP32 to encrypt uploads and calibration requests.
2. Run Flask with SSL context to serve over HTTPS
3. Document the new secure data path in the README